### PR TITLE
Fix a bug where user can enter word not from Electrum list.

### DIFF
--- a/extjs/mnemonic.js
+++ b/extjs/mnemonic.js
@@ -27,6 +27,14 @@ function mn_decode(str) {
     var out = '';
     var n = mn_words.length;
     var wlist = str.split(' ');
+
+    // throw an error if non electrum word is given in the input
+    wlist.forEach(function (word) {
+        if (mn_words.indexOf(word) == -1) {
+            throw ("can't decode word '"+ word +"' which is not from Electrum (poetry) list");
+        }
+    });
+
     for (var i = 0; i < wlist.length; i += 3) {
         var w1 = mn_words.indexOf(wlist[i]);
         var w2 = (mn_words.indexOf(wlist[i+1])) % n;

--- a/js/carbonwallet.js
+++ b/js/carbonwallet.js
@@ -139,7 +139,14 @@ $(document).ready(function() {
     
     if(password.split(' ').length != 12)
       valid = false;
-      
+
+      //make sure each word is a valid one from elctrum poetry list (mn_words variable)
+      password.split(' ').forEach(function (word) {
+          if (mn_words.indexOf(word) == -1) {
+              valid = false;
+          }
+      });
+
     if(valid)
     {
       $('#open-sesame').addClass('btn-primary');


### PR DESCRIPTION
Here is a fix to an issue where user can enter non Electrum words and still be able to operate his wallet.
This addresses issue #12 and #13
This update increases security, however it is a breaking change for users whose security is already affected.

I can come up with error message notification for affected users if you wish so.
